### PR TITLE
Update registration crawling, verify that user and institution crawling work, clean up code a little.

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -41,17 +41,13 @@ class Crawler:
             self.date_modified_marker = date_modified
 
         self.node_urls = []  # urls for the node-related pages, in time order from oldest to newest, grouped by node
-
-        self._wikis_by_parent_guid = collections.defaultdict(list) # private instance variable for wiki utils
+        self.registration_urls = []
+        self._node_wikis_by_parent_guid = collections.defaultdict(list)  # private instance variable for wiki utils
+        self._registration_wikis_by_parent_guid = collections.defaultdict(list)
 
         # For sorting
         self.node_url_tuples = []
-
-        self.registration_dashboard_page_list = []
-        self.registration_files_page_list = []
-        self.registration_wiki_page_list = []
-        self.registration_analytics_page_list = []
-        self.registration_forks_page_list = []
+        self.registration_url_tuples = []
 
         self.user_profile_page_list = [] # User profile page ("osf.io/profile/mst3k/")
         # Shoehorn index in to list of pages to scrape:
@@ -185,13 +181,11 @@ class Crawler:
                 for element in data:
                     date_str = element['attributes']['date_modified']
                     if '.' in date_str:
-                        date = datetime.datetime.strptime(element['attributes']['date_modified'],
-                                                          "%Y-%m-%dT%H:%M:%S.%f")
+                        date = datetime.datetime.strptime(date_str,"%Y-%m-%dT%H:%M:%S.%f")
                     else:
-                        date = datetime.datetime.strptime(element['attributes']['date_modified'], "%Y-%m-%dT%H:%M:%S")
+                        date = datetime.datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%S")
                     self.node_url_tuples.append((self.http_base + 'project/' + element['id'] + '/', date))
                     self.node_url_tuples.sort(key=lambda x: x[1])
-
 
     async def parse_registrations_api(self, api_url, sem):
         print('API request sent')
@@ -201,14 +195,23 @@ class Crawler:
                 body = await response.read()
                 response.close()
                 json_body = json.loads(body.decode('utf-8'))
-                print(api_url)
+                # print(api_url)
                 data = json_body['data']
                 for element in data:
-                    self.registration_dashboard_page_list.append(self.http_base + element['id'] + '/')
-                    self.registration_files_page_list.append(self.http_base + element['id'] + '/files/')
-                    self.registration_analytics_page_list.append(self.http_base + element['id'] + '/analytics/')
-                    self.registration_forks_page_list.append(self.http_base + element['id'] + '/forks/')
-                    # self.registration_
+                    # print(element)
+                    date_str = element['attributes']['date_modified']
+                    # print(date_str)
+                    # TODO: probably not a good long term solution. should change this
+                    if date_str is None:
+                        date_str = element['attributes']['date_registered']
+                    if '.' in date_str:
+                        date = datetime.datetime.strptime(date_str,"%Y-%m-%dT%H:%M:%S.%f")
+                    else:
+                        date = datetime.datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%S")
+                    # print(date)
+                    self.registration_url_tuples.append((self.http_base + element['id'] + '/', date))
+                    # print(self.registration_url_tuples)
+                    self.registration_url_tuples.sort(key=lambda x: x[1])
 
     async def parse_users_api(self, api_url, sem):
         print('API request sent')
@@ -259,9 +262,9 @@ class Crawler:
             if all_pages or files:
                 self.node_urls.append(base_url + 'files/')
             if all_pages or wiki:
-                wiki_name_list = self._wikis_by_parent_guid[base_url.strip("/").split("/")[-1]]
+                wiki_name_list = self._node_wikis_by_parent_guid[base_url.strip("/").split("/")[-1]]
                 wiki_url_list = [base_url + 'wiki/' + urllib.parse.quote(x) for x in wiki_name_list]
-                print("adding " + str(wiki_url_list) + " to to_scrape list")
+                # print("adding " + str(wiki_url_list) + " to to_scrape list")
                 self.node_urls += wiki_url_list
 
                 # the strip split -1 bit returns the last section of the base_url, which is the GUId
@@ -272,16 +275,46 @@ class Crawler:
             if all_pages or forks:
                 self.node_urls.append(base_url + 'forks/')
 
+    def generate_registration_urls(self, all_pages=True, dashboard=False, files=False,
+                                wiki=False, analytics=False, forks=False):
 
-    def crawl_wiki(self):
+        self.debug_logger.info("Generating registration urls")
+        self.debug_logger.info(" all_pages = " + str(all_pages) +
+                               " dashboard = " + str(dashboard) +
+                               " files = " + str(files) +
+                               " wiki = " + str(wiki) +
+                               "analytics = " + str(analytics) +
+                               " forks = " + str(forks)
+                               )
+
+        url_list = [x[0] for x in self.registration_url_tuples]
+
+        print("Generating Registration URLs...")
+        for base_url in url_list:
+            if all_pages or dashboard:
+                self.registration_urls.append(base_url)
+            if all_pages or files:
+                self.registration_urls.append(base_url + 'files/')
+            if all_pages or wiki:
+                # the strip split -1 bit returns the last section of the base_url, which is the GUId
+                wiki_name_list = self._registration_wikis_by_parent_guid[base_url.strip("/").split("/")[-1]]
+                wiki_url_list = [base_url + 'wiki/' + urllib.parse.quote(x) for x in wiki_name_list]
+                # print("adding " + str(wiki_url_list) + " to to_scrape list")
+                self.registration_urls += wiki_url_list
+            if all_pages or analytics:
+                self.registration_urls.append(base_url + 'analytics/')
+            if all_pages or forks:
+                self.registration_urls.append(base_url + 'forks/')
+
+    def crawl_node_wiki(self):
         tasks = []
         for node_url in [x[0] for x in self.node_url_tuples]:
-            tasks.append(asyncio.ensure_future(self.get_wiki_names(node_url.strip('/').split('/')[-1])))
+            tasks.append(asyncio.ensure_future(self.get_node_wiki_names(node_url.strip('/').split('/')[-1])))
         loop = asyncio.get_event_loop()
         loop.run_until_complete(asyncio.wait(tasks))
 
     # Async method called by crawl_wiki
-    async def get_wiki_names(self, parent_node):
+    async def get_node_wiki_names(self, parent_node):
         async with aiohttp.ClientSession() as s:
             u = self.api_base + 'nodes/' + parent_node + '/wikis/'
             response = await s.get(u)
@@ -291,8 +324,30 @@ class Crawler:
                 json_body = json.loads(body.decode('utf-8'))
                 data = json_body['data']
                 for datum in data:
-                    self._wikis_by_parent_guid[parent_node].append(datum['attributes']['name'])
-            print(u + ': ', response.status)
+                    self._node_wikis_by_parent_guid[parent_node].append(datum['attributes']['name'])
+            # print(u + ': ', response.status)
+
+    def crawl_registration_wiki(self):
+        tasks = []
+        for node_url in [x[0] for x in self.registration_url_tuples]:
+            tasks.append(asyncio.ensure_future(self.get_registration_wiki_names(node_url.strip('/').split('/')[-1])))
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(asyncio.wait(tasks))
+        # print(self._registration_wikis_by_parent_guid)
+
+    # Async method called by crawl_wiki
+    async def get_registration_wiki_names(self, parent_node):
+        async with aiohttp.ClientSession() as s:
+            u = self.api_base + 'registrations/' + parent_node + '/wikis/'
+            response = await s.get(u)
+            body = await response.read()
+            response.close()
+            if response.status <= 200:
+                json_body = json.loads(body.decode('utf-8'))
+                data = json_body['data']
+                for datum in data:
+                    self._registration_wikis_by_parent_guid[parent_node].append(datum['attributes']['name'])
+            # print(u + ': ', response.status)
 
     def scrape_nodes(self, async=True):
         self.debug_logger.info("Scraping nodes, async = " + str(async))
@@ -339,6 +394,8 @@ class Crawler:
 
 def save_html(html, page):
     page = page.split('//', 1)[1]
+    if page[-1] != '/':
+        page += '/'
     make_dirs(page)
     f = open(page + 'index.html', 'wb+')
     f.write(html)
@@ -356,19 +413,19 @@ def make_dirs(filename):
 #
 
 rosie = Crawler()
-#
-# # Get URLs from API and add them to the async tasks
-# rosie.crawl_nodes_api(page_limit=1)
-# rosie.crawl_wiki()
-# rosie.generate_node_urls(all_pages=True)
-# rosie.scrape_nodes(async=True)
 
-# rosie.crawl_institutions_api(page_limit=1)
+# # registration URLs
+# print("getting registration URLs...")
 # rosie.crawl_registrations_api(page_limit=1)
-# rosie.crawl_users_api(page_limit=1)
+# rosie.crawl_registration_wiki()
+# rosie.generate_registration_urls()
+# print("REGISTRATIONS: " + str(rosie.registration_urls))
 #
-# rosie._scrape_pages(rosie.institution_url_list)
-# rosie._scrape_pages(rosie.user_profile_page_list)
-# rosie._scrape_pages(rosie.registrations_url_list)
+#
+# # node URLs
+# print("getting node URLs...")
+# rosie.crawl_nodes_api(page_limit=1)
+# rosie.crawl_node_wiki()
+# rosie.generate_node_urls()
+# print("NODES: " + str(rosie.node_urls))
 
-# print("Mirror complete. \nOptional:\tRun verification testing suite.")

--- a/crawler.py
+++ b/crawler.py
@@ -195,12 +195,9 @@ class Crawler:
                 body = await response.read()
                 response.close()
                 json_body = json.loads(body.decode('utf-8'))
-                # print(api_url)
                 data = json_body['data']
                 for element in data:
-                    # print(element)
                     date_str = element['attributes']['date_modified']
-                    # print(date_str)
                     # TODO: probably not a good long term solution. should change this
                     if date_str is None:
                         date_str = element['attributes']['date_registered']
@@ -208,9 +205,7 @@ class Crawler:
                         date = datetime.datetime.strptime(date_str,"%Y-%m-%dT%H:%M:%S.%f")
                     else:
                         date = datetime.datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%S")
-                    # print(date)
                     self.registration_url_tuples.append((self.http_base + element['id'] + '/', date))
-                    # print(self.registration_url_tuples)
                     self.registration_url_tuples.sort(key=lambda x: x[1])
 
     async def parse_users_api(self, api_url, sem):
@@ -264,7 +259,6 @@ class Crawler:
             if all_pages or wiki:
                 wiki_name_list = self._node_wikis_by_parent_guid[base_url.strip("/").split("/")[-1]]
                 wiki_url_list = [base_url + 'wiki/' + urllib.parse.quote(x) for x in wiki_name_list]
-                # print("adding " + str(wiki_url_list) + " to to_scrape list")
                 self.node_urls += wiki_url_list
 
                 # the strip split -1 bit returns the last section of the base_url, which is the GUId
@@ -299,7 +293,6 @@ class Crawler:
                 # the strip split -1 bit returns the last section of the base_url, which is the GUId
                 wiki_name_list = self._registration_wikis_by_parent_guid[base_url.strip("/").split("/")[-1]]
                 wiki_url_list = [base_url + 'wiki/' + urllib.parse.quote(x) for x in wiki_name_list]
-                # print("adding " + str(wiki_url_list) + " to to_scrape list")
                 self.registration_urls += wiki_url_list
             if all_pages or analytics:
                 self.registration_urls.append(base_url + 'analytics/')
@@ -325,7 +318,6 @@ class Crawler:
                 data = json_body['data']
                 for datum in data:
                     self._node_wikis_by_parent_guid[parent_node].append(datum['attributes']['name'])
-            # print(u + ': ', response.status)
 
     def crawl_registration_wiki(self):
         tasks = []
@@ -333,7 +325,6 @@ class Crawler:
             tasks.append(asyncio.ensure_future(self.get_registration_wiki_names(node_url.strip('/').split('/')[-1])))
         loop = asyncio.get_event_loop()
         loop.run_until_complete(asyncio.wait(tasks))
-        # print(self._registration_wikis_by_parent_guid)
 
     # Async method called by crawl_wiki
     async def get_registration_wiki_names(self, parent_node):
@@ -347,7 +338,6 @@ class Crawler:
                 data = json_body['data']
                 for datum in data:
                     self._registration_wikis_by_parent_guid[parent_node].append(datum['attributes']['name'])
-            # print(u + ': ', response.status)
 
     def scrape_nodes(self, async=True):
         self.debug_logger.info("Scraping nodes, async = " + str(async))
@@ -388,7 +378,6 @@ class Crawler:
                     save_html(body, url)
                     print(str(response.status) + ": " + url)
                 if response.status == 504:
-                    # self.debug_logger.debug("504 on : " + url)
                     self.debug_logger.error("504 on : " + url)
 
 
@@ -407,25 +396,3 @@ def make_dirs(filename):
     folder = os.path.dirname(filename)
     if not os.path.exists(folder):
         os.makedirs(folder)
-
-#
-# # Execution
-#
-
-rosie = Crawler()
-
-# # registration URLs
-# print("getting registration URLs...")
-# rosie.crawl_registrations_api(page_limit=1)
-# rosie.crawl_registration_wiki()
-# rosie.generate_registration_urls()
-# print("REGISTRATIONS: " + str(rosie.registration_urls))
-#
-#
-# # node URLs
-# print("getting node URLs...")
-# rosie.crawl_nodes_api(page_limit=1)
-# rosie.crawl_node_wiki()
-# rosie.generate_node_urls()
-# print("NODES: " + str(rosie.node_urls))
-

--- a/tests.py
+++ b/tests.py
@@ -25,14 +25,14 @@ class test_crawler(unittest.TestCase):
         for t in c.node_url_tuples:
             self.assertTrue(is_valid_url(t[0]))
 
-    # def test_registration_urls_updated_by_crawl(self):
-    #     c = Crawler()
-    #     l1 = c.registration_url_tuples.copy()
-    #     c.crawl_registrations_api(page_limit=1)
-    #     l2 = c.registration_url_tuples.copy()
-    #     self.assertEqual(len(l1), 0)
-    #     self.assertGreater(len(l2), len(l1))
-    #     self.assertNotEqual(l1, l2)
+    def test_registration_urls_updated_by_crawl(self):
+        c = Crawler()
+        l1 = c.registration_url_tuples.copy()
+        c.crawl_registrations_api(page_limit=1)
+        l2 = c.registration_url_tuples.copy()
+        self.assertEqual(len(l1), 0)
+        self.assertGreater(len(l2), len(l1))
+        self.assertNotEqual(l1, l2)
 
     def test_institutions_urls_updated_by_crawl(self):
         c = Crawler()
@@ -52,12 +52,22 @@ class test_crawler(unittest.TestCase):
         self.assertGreater(len(l2), len(l1))
         self.assertNotEqual(l1, l2)
 
-    def test_wiki_urls_updated_by_crawl(self):  # needs node_url_tuples to work
+    def test_node_wiki_urls_updated_by_crawl(self):  # needs node_url_tuples to work
         c = Crawler()
         c.crawl_nodes_api(page_limit=1)
-        l1 = c._wikis_by_parent_guid.copy()
-        c.crawl_wiki()
-        l2 = c._wikis_by_parent_guid.copy()
+        l1 = c._node_wikis_by_parent_guid.copy()
+        c.crawl_node_wiki()
+        l2 = c._node_wikis_by_parent_guid.copy()
+        self.assertEqual(len(l1), 0)
+        self.assertGreater(len(l2), len(l1))
+        self.assertNotEqual(l1, l2)
+
+    def test_registration_wiki_urls_updated_by_crawl(self):  # needs node_url_tuples to work
+        c = Crawler()
+        c.crawl_registrations_api(page_limit=1)
+        l1 = c._registration_wikis_by_parent_guid.copy()
+        c.crawl_registration_wiki()
+        l2 = c._registration_wikis_by_parent_guid.copy()
         self.assertEqual(len(l1), 0)
         self.assertGreater(len(l2), len(l1))
         self.assertNotEqual(l1, l2)
@@ -73,8 +83,9 @@ class test_crawler(unittest.TestCase):
     def test_scrape_url(self):
         c = Crawler()
         try:
-            c._scrape_pages(['http://google.com'])  # we need to put a slash at the end of each URL
+            c._scrape_pages(['http://google.com', 'http://google.com/'])
             f = open('google.com/index.html')
+            f.close()
         except:
             self.fail("page didn't save / get scraped at all")
 


### PR DESCRIPTION
### Changes
1. Made another dict for specifically registration wikis, renamed the other to be specifically for node wikis.
2. generate_registration_urls is now the exact same as generate_node_urls except that it uses its own respectfully-named variables and sub-methods, and doesn't include a "/registrations/" sub category, because one doesn't exist for registrations
3. Cleaned up code involving datetime objects
4. Added tests mirroring the ones for nodes, but for registrations.
5. Fixed a possible bad situation where the directory creation would fail if there wasn't a trailing slash in the URL. This should never happen, but better safe than sorry I guess.
