### PR TITLE
Doubly fix a problem in wiki naming

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -275,7 +275,7 @@ class Crawler:
                 self.node_urls.append(base_url + 'files/')
             if all_pages or wiki:
                 wiki_name_list = self._node_wikis_by_parent_guid[base_url.strip("/").split("/")[-1]]
-                wiki_url_list = [base_url + 'wiki/' + urllib.parse.quote(x) for x in wiki_name_list]
+                wiki_url_list = [base_url + 'wiki/' + urllib.parse.quote(x) + '/' for x in wiki_name_list]
                 self.node_urls += wiki_url_list
 
                 # the strip split -1 bit returns the last section of the base_url, which is the GUId
@@ -311,7 +311,7 @@ class Crawler:
             if all_pages or wiki:
                 # the strip split -1 bit returns the last section of the base_url, which is the GUId
                 wiki_name_list = self._registration_wikis_by_parent_guid[base_url.strip("/").split("/")[-1]]
-                wiki_url_list = [base_url + 'wiki/' + urllib.parse.quote(x) for x in wiki_name_list]
+                wiki_url_list = [base_url + 'wiki/' + urllib.parse.quote(x) + '/' for x in wiki_name_list]
                 self.registration_urls += wiki_url_list
             if all_pages or analytics:
                 self.registration_urls.append(base_url + 'analytics/')


### PR DESCRIPTION
Wiki files were getting saved with names like homeindex.html instead of home/index.html. This fixes that problem.
