### PR TITLE
Introduce installation section, virtualenv documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ settings.py
 !task_file_example.txt
 *.json
 archive/
+!requirements.txt

--- a/README.md
+++ b/README.md
@@ -10,6 +10,27 @@ Despite childish fears!"  - Unknown')
 ##### Static mirroring utility for the [Open Science Framework](osf.io), maintained by     the [Center for Open Science](cos.io).
   Visit the [COS Github](https://github.com/CenterForOpenScience/) for more innovations in   the *openness*, *integrity*, and *reproducibility* of scientific research.
 
+## Installation
+
+This software requires Python 3.5 for the aiohttp library. If desired, create a virtualenv:
+
+##### From scratch:
+
+`pip install virtualenv`
+
+##### Create virtualenv 'rosie':
+
+`mkvirtualenv rosie --python=python3.5`
+
+##### Switch into the rosie environment for the first time:
+
+`workon rosie`
+
+`pip install -r requirements.txt` to install dependency libraries.
+
+##### Enter/exit the virtual environment:
+
+`workon rosie`/`deactivate`
 
 
 ## ROSIEisms
@@ -64,7 +85,7 @@ There are various options for what areas of the OSF are preserved in a mirror. A
 The python file cli.py needs to be run in the command line. This project was developed on Mac, so Terminal on OS X is preferred. 
 
 ```bash
-python3 cli.py
+python cli.py
 ```
 
 Flags:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+aiohttp==0.21.6
+asyncio==3.4.3
+beautifulsoup4==4.4.1
+bs4==0.0.1
+chardet==2.3.0
+click==6.6
+requests==2.10.0


### PR DESCRIPTION
Important stuff.

We need a python3.5 environment to support aiohttp, so I included virtual env instructions.
Additionally, I generated a requirements.txt for all the dependencies.
